### PR TITLE
Bugifx: MapperEnvironmentOutdated.MapperTreeJson had wrong case.

### DIFF
--- a/src/PokeABytes.Application.Mappers/MapperEnvironment.cs
+++ b/src/PokeABytes.Application.Mappers/MapperEnvironment.cs
@@ -10,7 +10,7 @@ public static class MapperEnvironment
         Path.Combine(BuildEnvironment.ConfigurationDirectory, "github_api_settings.json");
     public static string MapperTreeJson => "mapper_tree.json";
     public static string OutdatedMapperTreeJson => 
-        Path.Combine(BuildEnvironment.ConfigurationDirectory, "mappers/outdated_mapper_tree.json");
+        Path.Combine(BuildEnvironment.ConfigurationDirectory, "Mappers/outdated_mapper_tree.json");
     public static string GithubChangeFilePath =>
         Path.Combine(BuildEnvironment.ConfigurationDirectory, MapperTreeJson);
     public static string MapperLocalDirectory => 


### PR DESCRIPTION
Both OutdatedMapperTreeJson and MapperLocalDirectory need to have the same case ("Mappers") for the directory name, or PokeAByte refuses to fetch mappers on non-windows.