### PR TITLE
PokeAByteProperty: Do not try to solve address w/o variables.

### DIFF
--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty_Malleable.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty_Malleable.cs
@@ -63,7 +63,7 @@ namespace PokeAByte.Domain.PokeAByteProperties
 
                 try
                 {
-                    IsMemoryAddressSolved = AddressMath.TrySolve(value, [], out var solvedAddress);
+                    IsMemoryAddressSolved = AddressMath.TrySolve(value, Instance.Variables, out var solvedAddress);
                     
                     if (IsMemoryAddressSolved == false)
                     {


### PR DESCRIPTION
I have noticed spike caused by NCalc when testing pokemon emerald. Root cause were the missing variables in `AddressMath.TrySolve` call in the AddressString setter. Which caused an exception to be thrown and caught only for AddressMath.TrySolve to be immediately called again with the instance variables.

The fix is to simply give the instance variables in the setter as well. This massively improves performance for both pokemon emerald mappers, especially at 4x emulation speed.