### PR TITLE
Performance

### DIFF
--- a/src/PokeAByte.Application/MemoryManager.cs
+++ b/src/PokeAByte.Application/MemoryManager.cs
@@ -47,14 +47,15 @@ namespace PokeAByte.Application
 
     public class MemoryNamespace : IMemoryNamespace
     {
-        public ICollection<IByteArray> Fragments { get; } = new List<IByteArray>();
+        public IList<IByteArray> Fragments { get; } = new List<IByteArray>();
 
         public void Fill(MemoryAddress memoryAddress, byte[] data)
         {
             int filledFragments = 0;
 
-            foreach (var fragment in Fragments)
+            for (int i = 0; i < Fragments.Count; i++)
             {
+                IByteArray? fragment = Fragments[i];
                 if (fragment.Contains(memoryAddress))
                 {
                     try
@@ -87,8 +88,9 @@ namespace PokeAByte.Application
 
         public ReadOnlySpan<byte> GetReadonlyBytes(MemoryAddress memoryAddress, int length)
         {
-            foreach (var fragment in Fragments)
+            for (int i = 0; i < Fragments.Count; i++)
             {
+                IByteArray? fragment = Fragments[i];
                 if (fragment.Contains(memoryAddress))
                 {
                     int offset = (int)(memoryAddress - fragment.StartingAddress);

--- a/src/PokeAByte.Application/MemoryManager.cs
+++ b/src/PokeAByte.Application/MemoryManager.cs
@@ -134,8 +134,7 @@ namespace PokeAByte.Application
             {
                 throw new Exception($"The destination array is not long enough. The destination array has a length of {Data.Length} where the source array has a length of {data.Length}.");
             }
-
-            Array.Copy(data, 0, Data, offset, data.Length);
+            data.AsSpan().CopyTo(Data);
         }
 
         public bool Contains(MemoryAddress memoryAddress)

--- a/src/PokeAByte.Application/PokeAByteInstance.cs
+++ b/src/PokeAByte.Application/PokeAByteInstance.cs
@@ -283,12 +283,15 @@ namespace PokeAByte.Application
 
             // Processor
             ProcessorStopwatch.Restart();
-
+            var propertiesChanged = new List<IPokeAByteProperty>();
             foreach (var property in Mapper.Properties.Values)
             {
                 try
                 {
                     property.ProcessLoop(MemoryContainerManager);
+                    if (property.FieldsChanged.Any()) {
+                        propertiesChanged.Add(property);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -318,8 +321,7 @@ namespace PokeAByte.Application
             // Fields Changed
             FieldsChangedStopwatch.Restart();
 
-            var propertiesChanged = Mapper.Properties.Values.Where(x => x.FieldsChanged.Any()).ToArray();
-            if (propertiesChanged.Length > 0)
+            if (propertiesChanged.Count > 0)
             {
                 try
                 {
@@ -330,8 +332,8 @@ namespace PokeAByte.Application
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, $"Could not send {propertiesChanged.Length} property change events.");
-                    throw new PropertyProcessException($"Could not send {propertiesChanged.Length} property change events.", ex);
+                    _logger.LogError(ex, $"Could not send {propertiesChanged.Count} property change events.");
+                    throw new PropertyProcessException($"Could not send {propertiesChanged.Count} property change events.", ex);
                 }
             }
 

--- a/src/PokeAByte.Application/PokeAByteInstance.cs
+++ b/src/PokeAByte.Application/PokeAByteInstance.cs
@@ -69,6 +69,7 @@ namespace PokeAByte.Application
 
             Mapper?.Dispose();
 
+            Driver?.Disconnect();
             Driver = null;
             Mapper = null;
             PlatformOptions = null;
@@ -94,7 +95,6 @@ namespace PokeAByte.Application
                 _logger.LogDebug("Creating PokeAByte mapper instance...");
 
                 Driver = driver;
-
                 await Driver.EstablishConnection();
 
                 // Load the mapper file.

--- a/src/PokeAByte.Application/PokeAByteInstance.cs
+++ b/src/PokeAByte.Application/PokeAByteInstance.cs
@@ -17,7 +17,7 @@ namespace PokeAByte.Application
         private ScriptConsole ScriptConsoleAdapter { get; }
         private CancellationTokenSource? ReadLoopToken { get; set; }
         private IMapperFilesystemProvider MapperFilesystemProvider { get; }
-        private IEnumerable<MemoryAddressBlock>? BlocksToRead { get; set; }
+        private IList<MemoryAddressBlock>? BlocksToRead { get; set; }
         public List<IClientNotifier> ClientNotifiers { get; }
         public bool Initalized { get; private set; }
         public IPokeAByteDriver? Driver { get; private set; }
@@ -244,7 +244,7 @@ namespace PokeAByte.Application
 
             foreach (var result in driverResult)
             {
-                MemoryContainerManager.DefaultNamespace.Fill(result.Key, result.Value);
+                MemoryContainerManager.DefaultNamespace.Fill(result.Start, result.Data);
             }
 
             ReadDriverStopwatch.Stop();

--- a/src/PokeAByte.Application/PokeAByteInstance.cs
+++ b/src/PokeAByte.Application/PokeAByteInstance.cs
@@ -68,7 +68,7 @@ namespace PokeAByte.Application
             ReadLoopToken = null;
 
             Mapper?.Dispose();
-            
+
             Driver = null;
             Mapper = null;
             PlatformOptions = null;
@@ -77,11 +77,11 @@ namespace PokeAByte.Application
             JavascriptModuleInstance = null;
             HasPreprocessor = false;
             HasPostprocessor = false;
-            
+
             MemoryContainerManager = new MemoryManager();
             State = [];
             Variables = [];
-            
+
             await ClientNotifiers.ForEachAsync(async x => await x.SendInstanceReset());
         }
 
@@ -284,12 +284,15 @@ namespace PokeAByte.Application
             // Processor
             ProcessorStopwatch.Restart();
             var propertiesChanged = new List<IPokeAByteProperty>();
+            object? reloadAddress;
+            Variables.TryGetValue("reload_addresses", out reloadAddress);
             foreach (var property in Mapper.Properties.Values)
             {
                 try
                 {
-                    property.ProcessLoop(MemoryContainerManager);
-                    if (property.FieldsChanged.Any()) {
+                    property.ProcessLoop(MemoryContainerManager, reloadAddress is true);
+                    if (property.FieldsChanged.Count > 0)
+                    {
                         propertiesChanged.Add(property);
                     }
                 }

--- a/src/PokeAByte.Domain/AddressMath.cs
+++ b/src/PokeAByte.Domain/AddressMath.cs
@@ -4,16 +4,15 @@ namespace PokeAByte.Domain;
 
 public static class AddressMath
 {
-    public static bool TrySolve(string? addressExpression, Dictionary<string, object?> variables, out MemoryAddress address)
+    public static bool TrySolve(Expression? addressExpression, Dictionary<string, object?> variables, out MemoryAddress address)
     {
-        if (string.IsNullOrEmpty(addressExpression))
+        if (addressExpression == null)
         {
             address = 0x00;
             return false;
         }
         try
         {
-            var expression = new Expression(addressExpression);
             foreach (var variable in variables)
             {
                 if (variable.Value == null)
@@ -27,18 +26,17 @@ public static class AddressMath
                     return false;
                 }
 
-                expression.Parameters[variable.Key] = variable.Value;
+                addressExpression.Parameters[variable.Key] = variable.Value;
             }
-
-            var result = expression.Evaluate();
-            if (result is int castedResult)
+            var result = addressExpression.Evaluate();
+            if (result is uint castedResult)
             {
-                address = (uint)castedResult;
+                address = castedResult;
                 return true;
             }
             else
             {
-                if (uint.TryParse(result.ToString(), out address))
+                if (uint.TryParse(result?.ToString(), out address))
                 {
                     return true;
                 }

--- a/src/PokeAByte.Domain/Extensions/ByteExtensions.cs
+++ b/src/PokeAByte.Domain/Extensions/ByteExtensions.cs
@@ -4,34 +4,24 @@ public static class ByteExtensions
 {
     public static byte[] ReverseBytesIfLE(this byte[] bytes, EndianTypes endianType)
     {
-        if (bytes.Length == 1) { return bytes; }
-
-        if (endianType == EndianTypes.LittleEndian)
-        {
-            var workingBytes = (byte[])bytes.Clone();
-
-            Array.Reverse(workingBytes);
-
-            return workingBytes;
+        if (bytes.Length == 1 || endianType != EndianTypes.LittleEndian) { 
+            return bytes; 
         }
 
-        return bytes;
+        var workingBytes = (byte[])bytes.Clone();
+        Array.Reverse(workingBytes);
+        return workingBytes;
     }
 
     public static byte[] ReverseBytesIfBE(this byte[] bytes, EndianTypes endianType)
     {
-        if (bytes.Length == 1) { return bytes; }
-
-        if (endianType == EndianTypes.BigEndian)
-        {
-            var workingBytes = (byte[])bytes.Clone();
-
-            Array.Reverse(workingBytes);
-
-            return workingBytes;
+        if (bytes.Length == 1 || endianType != EndianTypes.BigEndian) { 
+            return bytes; 
         }
 
-        return bytes;
+        var workingBytes = (byte[])bytes.Clone();
+        Array.Reverse(workingBytes);
+        return workingBytes;
     }
 
     private static byte[] PadBytes(byte[] data, int size)

--- a/src/PokeAByte.Domain/Extensions/Extensions.cs
+++ b/src/PokeAByte.Domain/Extensions/Extensions.cs
@@ -12,7 +12,7 @@ public static partial class Extensions
     public static string ToHexdecimalString(this byte value) => ((uint)value).ToHexdecimalString();
     public static string ToHexdecimalString(this IEnumerable<int> value, string joinCharacter = " ") => string.Join(joinCharacter, value.Select(x => ((uint)x).ToHexdecimalString()));
 
-    public static IEnumerable<int> ToIntegerArray(this byte[] bytes) => bytes.Select(x => (int)x).ToArray();
+    public static IEnumerable<int> ToIntegerArray(this byte[] bytes) => Array.ConvertAll(bytes, x => (int)x);
 
     /// <summary>
     /// Parse a hex memory address into a uint. 

--- a/src/PokeAByte.Domain/Interfaces/IClientNotifier.cs
+++ b/src/PokeAByte.Domain/Interfaces/IClientNotifier.cs
@@ -5,7 +5,7 @@ namespace PokeAByte.Domain.Interfaces
         Task SendInstanceReset();
         Task SendMapperLoaded(IPokeAByteMapper mapper);
         Task SendError(IProblemDetails problemDetails);
-        Task SendPropertiesChanged(IEnumerable<IPokeAByteProperty> properties);
+        Task SendPropertiesChanged(IList<IPokeAByteProperty> properties);
         
         public event PropertyChangedEventHandler? PropertyChangedEvent;
     }

--- a/src/PokeAByte.Domain/Interfaces/IMemoryManager.cs
+++ b/src/PokeAByte.Domain/Interfaces/IMemoryManager.cs
@@ -1,4 +1,6 @@
-﻿namespace PokeAByte.Domain.Interfaces
+﻿using System.Buffers.Binary;
+
+namespace PokeAByte.Domain.Interfaces
 {
     public interface IMemoryManager
     {
@@ -7,6 +9,7 @@
         IMemoryNamespace DefaultNamespace { get; }
 
         IByteArray Get(string? area, MemoryAddress memoryAddress, int length);
+        ReadOnlySpan<byte> GetReadonlyBytes(string? area, MemoryAddress memoryAddress, int length);
         void Fill(string area, MemoryAddress memoryAddress, byte[] data);
     }
 
@@ -16,36 +19,34 @@
 
         public void Fill(MemoryAddress memoryAddress, byte[] data);
         bool Contains(MemoryAddress memoryAddress);
+        ReadOnlySpan<byte> GetReadonlyBytes(MemoryAddress memoryAddress, int length);
 
         byte get_byte(MemoryAddress memoryAddress);
+
         IByteArray get_bytes(MemoryAddress memoryAddress, int length);
 
         public ushort get_uint16_le(MemoryAddress memoryAddress)
         {
-            var bytes = get_bytes(memoryAddress, 2).Data;
-            return (ushort)((bytes[0] << 0) | (bytes[1] << 8));
+            var bytes = GetReadonlyBytes(memoryAddress, 2);
+            return BinaryPrimitives.ReadUInt16LittleEndian(bytes);
         }
 
         public ushort get_uint16_be(MemoryAddress memoryAddress)
         {
-            var bytes = get_bytes(memoryAddress, 2).Data;
-            return (ushort)((bytes[0] << 8) | (bytes[1] << 0));
+            var bytes = GetReadonlyBytes(memoryAddress, 2);
+            return BinaryPrimitives.ReadUInt16BigEndian(bytes);
         }
 
         public uint get_uint32_le(MemoryAddress memoryAddress)
         {
-            var bytes = get_bytes(memoryAddress, 4).Data;
-            int lower = (bytes[0] << 0) | (bytes[1] << 8);
-            int upper = (bytes[2] << 0) | (bytes[3] << 8);
-            return (uint)((lower << 0) | (upper << 16));
+            var bytes = GetReadonlyBytes(memoryAddress, 4);
+            return BinaryPrimitives.ReadUInt32LittleEndian(bytes);
         }
 
         public uint get_uint32_be(MemoryAddress memoryAddress)
         {
-            var bytes = get_bytes(memoryAddress, 4).Data;
-            int lower = (bytes[0] << 8) | (bytes[1] << 0);
-            int upper = (bytes[2] << 8) | (bytes[3] << 0);
-            return (uint)((lower << 16) | (upper << 0));
+            var bytes = GetReadonlyBytes(memoryAddress, 4);
+            return BinaryPrimitives.ReadUInt32BigEndian(bytes);
         }
 
         public ulong get_uint64_le(MemoryAddress memoryAddress) => (ulong)((get_uint32_le(memoryAddress + 0) << 0) | (get_uint32_le(memoryAddress + 4) << 32));

--- a/src/PokeAByte.Domain/Interfaces/IMemoryManager.cs
+++ b/src/PokeAByte.Domain/Interfaces/IMemoryManager.cs
@@ -15,7 +15,7 @@ namespace PokeAByte.Domain.Interfaces
 
     public interface IMemoryNamespace
     {
-        ICollection<IByteArray> Fragments { get; }
+        IList<IByteArray> Fragments { get; }
 
         public void Fill(MemoryAddress memoryAddress, byte[] data);
         bool Contains(MemoryAddress memoryAddress);

--- a/src/PokeAByte.Domain/Interfaces/IMemoryManager.cs
+++ b/src/PokeAByte.Domain/Interfaces/IMemoryManager.cs
@@ -20,10 +20,34 @@
         byte get_byte(MemoryAddress memoryAddress);
         IByteArray get_bytes(MemoryAddress memoryAddress, int length);
 
-        public ushort get_uint16_le(MemoryAddress memoryAddress) => (ushort)((get_byte(memoryAddress + 0) << 0) | (get_byte(memoryAddress + 1) << 8));
-        public ushort get_uint16_be(MemoryAddress memoryAddress) => (ushort)((get_byte(memoryAddress + 0) << 8) | (get_byte(memoryAddress + 1) << 0));
-        public uint get_uint32_le(MemoryAddress memoryAddress) => (uint)((get_uint16_le(memoryAddress + 0) << 0) | (get_uint16_le(memoryAddress + 2) << 16));
-        public uint get_uint32_be(MemoryAddress memoryAddress) => (uint)((get_uint16_be(memoryAddress + 0) << 16) | (get_uint16_be(memoryAddress + 2) << 0));
+        public ushort get_uint16_le(MemoryAddress memoryAddress)
+        {
+            var bytes = get_bytes(memoryAddress, 2).Data;
+            return (ushort)((bytes[0] << 0) | (bytes[1] << 8));
+        }
+
+        public ushort get_uint16_be(MemoryAddress memoryAddress)
+        {
+            var bytes = get_bytes(memoryAddress, 2).Data;
+            return (ushort)((bytes[0] << 8) | (bytes[1] << 0));
+        }
+
+        public uint get_uint32_le(MemoryAddress memoryAddress)
+        {
+            var bytes = get_bytes(memoryAddress, 4).Data;
+            int lower = (bytes[0] << 0) | (bytes[1] << 8);
+            int upper = (bytes[2] << 0) | (bytes[3] << 8);
+            return (uint)((lower << 0) | (upper << 16));
+        }
+
+        public uint get_uint32_be(MemoryAddress memoryAddress)
+        {
+            var bytes = get_bytes(memoryAddress, 4).Data;
+            int lower = (bytes[0] << 8) | (bytes[1] << 0);
+            int upper = (bytes[2] << 8) | (bytes[3] << 0);
+            return (uint)((lower << 16) | (upper << 0));
+        }
+
         public ulong get_uint64_le(MemoryAddress memoryAddress) => (ulong)((get_uint32_le(memoryAddress + 0) << 0) | (get_uint32_le(memoryAddress + 4) << 32));
         public ulong get_uint64_be(MemoryAddress memoryAddress) => (ulong)((get_uint32_be(memoryAddress + 0) << 32) | (get_uint32_be(memoryAddress + 4) << 0));
     }

--- a/src/PokeAByte.Domain/Interfaces/IPokeAByteDriver.cs
+++ b/src/PokeAByte.Domain/Interfaces/IPokeAByteDriver.cs
@@ -1,5 +1,7 @@
 namespace PokeAByte.Domain.Interfaces
 {
+    public record BlockData(MemoryAddress Start, byte[] Data);
+
     /// <summary>
     /// Driver interface for interacting with a emulator.
     /// 
@@ -15,7 +17,7 @@ namespace PokeAByte.Domain.Interfaces
         Task EstablishConnection();
         Task<bool> TestConnection();
 
-        Task<Dictionary<uint, byte[]>> ReadBytes(IEnumerable<MemoryAddressBlock> blocks);
+        Task<BlockData[]> ReadBytes(IList<MemoryAddressBlock> blocks);
 
         Task WriteBytes(uint startingMemoryAddress, byte[] values, string? path = null);
     }

--- a/src/PokeAByte.Domain/Interfaces/IPokeAByteDriver.cs
+++ b/src/PokeAByte.Domain/Interfaces/IPokeAByteDriver.cs
@@ -15,6 +15,7 @@ namespace PokeAByte.Domain.Interfaces
         int DelayMsBetweenReads { get; }
 
         Task EstablishConnection();
+        Task Disconnect();
         Task<bool> TestConnection();
 
         Task<BlockData[]> ReadBytes(IList<MemoryAddressBlock> blocks);

--- a/src/PokeAByte.Domain/Interfaces/IPokeAByteMapper.cs
+++ b/src/PokeAByte.Domain/Interfaces/IPokeAByteMapper.cs
@@ -1,4 +1,6 @@
-﻿namespace PokeAByte.Domain.Interfaces
+﻿using PokeAByte.Domain.PokeAByteProperties;
+
+namespace PokeAByte.Domain.Interfaces
 {
     public class MetadataSection
     {
@@ -24,5 +26,52 @@
         MemorySection Memory { get; }
         Dictionary<string, IPokeAByteProperty> Properties { get; }
         Dictionary<string, ReferenceItems> References { get; }
+
+        /// <summary>
+        /// Copies all properties under the source path into the appopriate desitnation path properties. <br/>
+        /// The source and destination are identified by their partial paths.
+        /// If sourcepath is "gameTime" and destinationpath is "time", the properties are copied like this: <br/>
+        /// gameTime.seconds -> time.seconds <br/>
+        /// gameTime.minutes -> time.minutes <br/>
+        /// gameTime.hours -> time.hours <br/>
+        /// Assuming that "time.seconds", "time.minutes" and "time.hours" are defined properties. <br/>
+        /// If the calculated destination path does not exist, it is skipped. In the above example "gameTime.frames" 
+        /// will not be copied.
+        /// </summary>
+        /// <param name="sourcePath">
+        /// The partial path of the source properties to copy. 
+        /// </param>
+        /// <param name="destinationPath">
+        /// The partial path that the source properties will be copied to. 
+        /// </param>
+        /// <remarks>
+        /// This API is not used internally by PokeAByte, but may be invoked by the javascript of some mappers. <br/>
+        /// </remarks>
+        public void copy_properties(string sourcePath, string destinationPath)
+        {
+            var pathSpan = destinationPath.AsSpan();
+            int destPathLength = destinationPath.Length;
+
+            foreach (var key in Properties.Keys.Where(key => key.AsSpan().StartsWith(destinationPath)))
+            {
+                var property = Properties[key] as PokeAByteProperty;
+                if (property == null) {
+                    continue;
+                }
+                var sourceKey = string.Concat(sourcePath, key.Substring(destPathLength));
+                
+                if (Properties.TryGetValue(sourceKey, out var source))
+                {
+                    property.MemoryContainer = source.MemoryContainer;
+                    property.Address = source.Address;
+                    property.Length = source.Length;
+                    property.Size = source.Size;
+                    property.Bits = source.Bits;
+                    property.Reference = source.Reference;
+                    property.Bytes = source.Bytes;
+                    property.Value = source.Value;
+                }
+            }
+        }
     }
 }

--- a/src/PokeAByte.Domain/Interfaces/IPokeAByteProperty.cs
+++ b/src/PokeAByte.Domain/Interfaces/IPokeAByteProperty.cs
@@ -46,7 +46,7 @@
 
         HashSet<string> FieldsChanged { get; }
 
-        void ProcessLoop(IMemoryManager container);
+        void ProcessLoop(IMemoryManager container, bool reloadAddresses);
         byte[] BytesFromBits(byte[] bytes);
         object? CalculateObjectValue(byte[] bytes);
         Task WriteValue(string value, bool? freeze);

--- a/src/PokeAByte.Domain/Models/Properties/PropertyModel.cs
+++ b/src/PokeAByte.Domain/Models/Properties/PropertyModel.cs
@@ -62,9 +62,8 @@ public static class PropertyModelExtensions
         {
             original.Value = updated.Value;
         }
-
-        if (updated.Bytes != null &&
-            (original.Bytes is null ||
+        if (updated.Bytes != null && 
+            (original.Bytes is null || 
              !updated.Bytes
                  .ToIntegerArray()
                  .SequenceEqual(original.Bytes)))

--- a/src/PokeAByte.Domain/PokeAByteProperties/BooleanProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/BooleanProperty.cs
@@ -1,22 +1,23 @@
 ﻿using PokeAByte.Domain.Interfaces;
+using PokeAByte.Domain.PokeAByteProperties;
 
-namespace PokeAByte.Domain.PokeAByteProperties
+namespace PokeAByte.Domain;
+
+public class BooleanProperty : PokeAByteProperty, IPokeAByteProperty
 {
-    public class BooleanProperty : PokeAByteProperty, IPokeAByteProperty
+    public BooleanProperty(IPokeAByteInstance instance, PropertyAttributes variables) : base(instance, variables)
     {
-        public BooleanProperty(IPokeAByteInstance instance, PropertyAttributes variables) : base(instance, variables)
-        {
-        }
+    }
 
-        protected override byte[] FromValue(string value)
-        {
-            var booleanValue = bool.Parse(value);
-            return booleanValue == true ? new byte[] { 0x01 } : new byte[] { 0x00 };
-        }
+    protected override byte[] FromValue(string value)
+    {
+        var booleanValue = bool.Parse(value);
+        return booleanValue == true ? [0x01] : [0x00];
+    }
 
-        protected override object? ToValue(byte[] data)
-        {
-            return data[0] == 0x00 ? false : true;
-        }
+    protected override object? ToValue(byte[] data)
+    {
+        return data[0] != 0x00;
     }
 }
+

--- a/src/PokeAByte.Domain/PokeAByteProperties/IntegerProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/IntegerProperty.cs
@@ -1,32 +1,39 @@
 ﻿using PokeAByte.Domain.Interfaces;
 
-namespace PokeAByte.Domain.PokeAByteProperties
+namespace PokeAByte.Domain.PokeAByteProperties;
+
+public class IntegerProperty : PokeAByteProperty
 {
-    public class IntegerProperty : PokeAByteProperty
+    public IntegerProperty(IPokeAByteInstance instance, PropertyAttributes variables) : base(instance, variables)
     {
-        public IntegerProperty(IPokeAByteInstance instance, PropertyAttributes variables) : base(instance, variables)
-        {
-        }
+    }
 
-        protected override byte[] FromValue(string value)
-        {
-            if (Instance == null) throw new Exception("Instance is NULL.");
-            if (Instance.PlatformOptions == null) throw new Exception("Instance.PlatformOptions is NULL.");
-            if (Length == null) throw new Exception("Length is NULL.");
-            
-            var integerValue = int.Parse(value);
-            var bytes = BitConverter.GetBytes(integerValue).Take(Length ?? 0).ToArray();
-            return bytes.ReverseBytesIfLE(Instance.PlatformOptions.EndianType);
-        }
+    protected override byte[] FromValue(string value)
+    {
+        if (Instance == null) throw new Exception("Instance is NULL.");
+        if (Instance.PlatformOptions == null) throw new Exception("Instance.PlatformOptions is NULL.");
+        if (Length == null) throw new Exception("Length is NULL.");
+        var integerValue = int.Parse(value);
+        var bytes = BitConverter.GetBytes(integerValue).Take(Length ?? 0).ToArray();
+        return bytes.ReverseBytesIfLE(Instance.PlatformOptions.EndianType);
+    }
 
-        protected override object? ToValue(byte[] data)
+    protected override object? ToValue(byte[] data)
+    {
+        if (Instance == null) throw new Exception("Instance is NULL.");
+        if (Instance.PlatformOptions == null) throw new Exception("Instance.PlatformOptions is NULL.");
+        if (data.Length == 1)
         {
-            if (Instance == null) throw new Exception("Instance is NULL.");
-            if (Instance.PlatformOptions == null) throw new Exception("Instance.PlatformOptions is NULL.");
-
-            byte[] value = new byte[8];
-            Array.Copy(data.ReverseBytesIfLE(Instance.PlatformOptions.EndianType), value, data.Length);
-            return BitConverter.ToInt32(value, 0);
+            // Shortcut: With one byte, we can just cast:
+            return (int)data[0];
         }
+        if (data.Length >= 4)
+        {
+            return BitConverter.ToInt32(data.ReverseBytesIfLE(Instance.PlatformOptions.EndianType), 0);
+        }
+        // With less than 4 bytes, we have to pad the value before using the bitconverter:
+        Span<byte> value = stackalloc byte[4];
+        data.ReverseBytesIfLE(Instance.PlatformOptions.EndianType).AsSpan().CopyTo(value);
+        return BitConverter.ToInt32(value);
     }
 }

--- a/src/PokeAByte.Domain/PokeAByteProperties/StringProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/StringProperty.cs
@@ -1,89 +1,92 @@
 ﻿using PokeAByte.Domain.Interfaces;
 
-namespace PokeAByte.Domain.PokeAByteProperties
+namespace PokeAByte.Domain.PokeAByteProperties;
+
+public class StringProperty : PokeAByteProperty, IPokeAByteProperty
 {
-    public class StringProperty : PokeAByteProperty, IPokeAByteProperty
+    public StringProperty(IPokeAByteInstance instance, PropertyAttributes variables) : base(instance, variables)
     {
-        public StringProperty(IPokeAByteInstance instance, PropertyAttributes variables) : base(instance, variables)
+        if (Reference == null)
         {
-            if (Reference == null)
-            {
-                Reference = "defaultCharacterMap";
-            }
+            Reference = "defaultCharacterMap";
+        }
+    }
+
+    protected override byte[] FromValue(string value)
+    {
+        if (ComputedReference == null) throw new Exception("ReferenceObject is NULL.");
+        if (Length == null) throw new Exception("Length is NULL.");
+
+        var uints = value
+            .Select(x => ComputedReference.Values.FirstOrDefault(y => x.ToString() == y?.Value?.ToString()))
+            .ToList();
+
+        if (uints.Count + 1 > Length)
+        {
+            uints = uints.Take(Length ?? 0 - 1).ToList();
         }
 
-        protected override byte[] FromValue(string value)
-        {
-            if (ComputedReference == null) throw new Exception("ReferenceObject is NULL.");
-            if (Length == null) throw new Exception("Length is NULL.");
-
-            var uints = value
-                .Select(x => ComputedReference.Values.FirstOrDefault(y => x.ToString() == y?.Value?.ToString()))
-                .ToList();
-            
-            if (uints.Count + 1 > Length)
+        var nullTerminationKey = ComputedReference.Values.First(x => x.Value == null);
+        uints.Add(nullTerminationKey);
+        /*var returnBytes = ulongArray
+            .Select(x => (byte)x)
+            .ToArray();*/
+        return uints
+            .Select(x =>
             {
-                uints = uints.Take(Length ?? 0 - 1).ToList();
-            }
-
-            var nullTerminationKey = ComputedReference.Values.First(x => x.Value == null);
-            uints.Add(nullTerminationKey);
-            /*var returnBytes = ulongArray
-                .Select(x => (byte)x)
-                .ToArray();*/
-            return uints
-                .Select(x =>
+                if (x?.Value == null)
                 {
-                    if (x?.Value == null)
-                    {
-                        return nullTerminationKey.Key;
-                    }
+                    return nullTerminationKey.Key;
+                }
 
-                    return x.Key;
-                }).SelectMany(x =>
-                {
-                    if(Size is null)
-                        return BitConverter
-                            .GetBytes(x)
-                            .Take(new Range(0,1));
+                return x.Key;
+            }).SelectMany(x =>
+            {
+                if (Size is null)
                     return BitConverter
                         .GetBytes(x)
-                        .Take(Size ?? 1);
-                })
-                .ToArray();
-        }
+                        .Take(new Range(0, 1));
+                return BitConverter
+                    .GetBytes(x)
+                    .Take(Size ?? 1);
+            })
+            .ToArray();
+    }
 
-        protected override object? ToValue(byte[] data)
+    protected override object? ToValue(byte[] data)
+    {
+        if (Instance == null) throw new Exception("Instance is NULL.");
+        if (Instance.PlatformOptions == null) throw new Exception("Instance.PlatformOptions is NULL.");
+        if (ComputedReference == null) { throw new Exception("ReferenceObject is NULL."); }
+
+        string?[] results = Array.Empty<string>();
+
+        if (Size > 1)
         {
-            if (Instance == null) throw new Exception("Instance is NULL.");
-            if (Instance.PlatformOptions == null) throw new Exception("Instance.PlatformOptions is NULL.");
-            if (ComputedReference == null) { throw new Exception("ReferenceObject is NULL."); }
-
-            string?[] results = Array.Empty<string>();
-
-            if (Size > 1)
+            // For strings that have characters mapper to more than a single byte.
+            results = data.Chunk(Size.Value).Select(b =>
             {
-                // For strings that have characters mapper to more than a single byte.
-                results = data.Chunk(Size ?? 1).Select(b =>
-                {
-                    var value = b.ReverseBytesIfBE(Instance.PlatformOptions.EndianType).get_ulong_be();
+                var value = b.ReverseBytesIfBE(Instance.PlatformOptions.EndianType).get_ulong_be();
 
-                    var referenceItem = ComputedReference.Values.SingleOrDefault(x => x.Key == value);
-                    return referenceItem?.Value?.ToString() ?? null;
-                }).ToArray();
-            }
-            else
-            {
-                // For strings where one character equals one byte.
-                results = data.Select(b =>
-                {
-                    var referenceItem = ComputedReference.Values.SingleOrDefault(x => x.Key == b);
-                    return referenceItem?.Value?.ToString() ?? null;
-                }).ToArray();
-            }
-
+                var referenceItem = ComputedReference.Values.SingleOrDefault(x => x.Key == value);
+                return referenceItem?.Value?.ToString() ?? null;
+            }).ToArray();
             // Return the completed string buffer.
-            return string.Join(string.Empty, results.TakeWhile(s => s != null));
+            return string.Concat(results.TakeWhile(s => s != null));
         }
+
+        // For strings where one character equals one byte.
+        results = new string?[data.Length];
+        int i = 0;
+        for (; i < data.Length; i++)
+        {
+            var referenceItem = ComputedReference.Values.SingleOrDefault(x => x.Key == data[i]);
+            if (referenceItem?.Value == null)
+            {
+                break;
+            }
+            results[i] = referenceItem.Value.ToString();
+        }
+        return string.Concat(results[0..i]);
     }
 }

--- a/src/PokeAByte.Domain/PokeAByteProperties/UnsignedIntegerProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/UnsignedIntegerProperty.cs
@@ -1,5 +1,4 @@
 ﻿using PokeAByte.Domain.Interfaces;
-using PokeAByte.Domain.Models;
 
 namespace PokeAByte.Domain.PokeAByteProperties;
 
@@ -23,9 +22,19 @@ public class UnsignedIntegerProperty : PokeAByteProperty, IPokeAByteProperty
     {
         if (Instance == null) throw new Exception("Instance is NULL.");
         if (Instance.PlatformOptions == null) throw new Exception("Instance.PlatformOptions is NULL.");
-
-        byte[] value = new byte[8];
-        Array.Copy(data.ReverseBytesIfLE(Instance.PlatformOptions.EndianType), value, data.Length);
-        return BitConverter.ToUInt32(value, 0);
+        // Shortcut: With one byte, we can just cast:
+        if (data.Length == 1)
+        {
+            return (uint)data[0];
+        }
+        // With less than 4 bytes, we have to pad the value before using the bitconverter:
+        if (data.Length >= 4) 
+        {
+            return BitConverter.ToUInt32(data.ReverseBytesIfLE(Instance.PlatformOptions.EndianType), 0);
+        }
+        // With less than 4 bytes, we have to pad the value before using the bitconverter:
+        Span<byte> value = stackalloc byte[4];
+        data.ReverseBytesIfLE(Instance.PlatformOptions.EndianType).AsSpan().CopyTo(value);
+        return BitConverter.ToUInt32(value);
     }
 }

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
@@ -249,29 +249,36 @@ namespace PokeAByte.Domain.PokeAByteProperties
         {
             if (string.IsNullOrEmpty(Bits)) return bytes;
             int[] indexes;
-
-            if (Bits.Contains('-'))
+            ReadOnlySpan<char> bitsSpan = Bits.AsSpan();
+            if (bitsSpan.Contains('-'))
             {
-                var parts = Bits.Split('-');
+                var dashIndex = bitsSpan.IndexOf('-');
+                var part1 = bitsSpan.Slice(0, dashIndex);
+                var part2 = bitsSpan.Slice(dashIndex + 1);
 
-                if (int.TryParse(parts[0], out int start) && int.TryParse(parts[1], out int end))
+                if (int.TryParse(part1, out int start) && int.TryParse(part2, out int end))
                 {
                     indexes = Enumerable.Range(start, end - start + 1).ToArray();
                 }
                 else
                 {
-                    throw new ArgumentException($"Invalid format for attribute Bits ({Bits}) for path {Path}.");
+                    throw new ArgumentException($"Invalid format for attribute Bits ({Bits}).");
                 }
             }
-            else if (Bits.Contains(','))
+            else if (bitsSpan.Contains(','))
             {
-                indexes = Bits.Split(',')
-                    .Select(x => int.TryParse(x, out int num) ? num : throw new ArgumentException($"Invalid format for attribute Bits ({Bits}) for path {Path}."))
-                    .ToArray();
+                indexes = new int[bitsSpan.Count(',') + 1];
+                int x = 0;
+                foreach (var range in bitsSpan.Split(','))
+                {
+                    indexes[x++] = int.TryParse(bitsSpan[range], out int number)
+                        ? number
+                        : throw new ArgumentException($"Invalid format for attribute Bits ({Bits}).");
+                }
             }
             else
             {
-                if (int.TryParse(Bits, out int index))
+                if (int.TryParse(bitsSpan, out int index))
                 {
                     indexes = [index];
                 }

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
@@ -141,25 +141,21 @@ namespace PokeAByte.Domain.PokeAByteProperties
             }
 
             byte[]? previousBytes = Bytes?.ToArray();
-            byte[]? bytes = null;
+            byte[] bytes;
             object? value;
 
-            if (bytes == null)
-            {
-                if (address == null) { throw new Exception("address is NULL."); }
-                if (Length == null) { throw new Exception("Length is NULL."); }
+            if (address == null) { throw new Exception("address is NULL."); }
+            if (Length == null) { throw new Exception("Length is NULL."); }
 
-                try
-                {
-                    bytes = memoryManager.Get(MemoryContainer, address ?? 0x00, Length ?? 0).Data;
-                }
-                catch (Exception e)
-                {
-                    Address = null;
-                    bytes = [0];
-                }
+            try
+            {
+                bytes = memoryManager.Get(MemoryContainer, address ?? 0x00, Length ?? 0).Data;
             }
-            
+            catch (Exception)
+            {
+                Address = null;
+                bytes = [0];
+            }
             
             Address = address;
             

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
@@ -76,7 +76,7 @@ namespace PokeAByte.Domain.PokeAByteProperties
             => FromValue(FullValue?.ToString() ?? "");
         public HashSet<string> FieldsChanged { get; } = [];
 
-        public void ProcessLoop(IMemoryManager memoryManager)
+        public void ProcessLoop(IMemoryManager memoryManager, bool reloadAddresses)
         {
             if (Instance == null) { throw new Exception("Instance is NULL."); }
             if (Instance.Mapper == null) { throw new Exception("Instance.Mapper is NULL."); }
@@ -107,7 +107,7 @@ namespace PokeAByte.Domain.PokeAByteProperties
 
             MemoryAddress? address = Address;
 
-            if (Instance.Variables.TryGetValue("reload_addresses", out var reloadAddress) && reloadAddress is true)
+            if (reloadAddresses)
             {
                 AddressString = _originalAddressString;
             }

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
@@ -146,7 +146,17 @@ namespace PokeAByte.Domain.PokeAByteProperties
 
             try
             {
-                bytes = memoryManager.Get(MemoryContainer, address ?? 0x00, Length ?? 0).Data;
+                var readonlyBytes = memoryManager.GetReadonlyBytes(MemoryContainer, address ?? 0x00, Length ?? 0);
+                if (readonlyBytes.SequenceEqual(Bytes)) {
+                    // Fast path - if the bytes match, then we can assume the property has not been
+                    // updated since last poll.
+
+                    // Do nothing, we don't need to calculate the new value as
+                    // the bytes are the same.
+                    Address = address;
+                    return;
+                }
+                bytes = readonlyBytes.ToArray();
             }
             catch (Exception)
             {
@@ -155,17 +165,7 @@ namespace PokeAByte.Domain.PokeAByteProperties
             }
             
             Address = address;
-            
-            if (Bytes != null && Bytes.AsSpan().SequenceEqual(bytes))
-            {
-                // Fast path - if the bytes match, then we can assume the property has not been
-                // updated since last poll.
-
-                // Do nothing, we don't need to calculate the new value as
-                // the bytes are the same.
-                return;
-            }
-            
+                
             Bytes = bytes?.ToArray();
 
             if (bytes == null)

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
@@ -107,9 +107,7 @@ namespace PokeAByte.Domain.PokeAByteProperties
 
             MemoryAddress? address = Address;
 
-            var reloadAddressKvp = Instance.Variables
-                .FirstOrDefault(x => x.Key == "reload_addresses");
-            if (reloadAddressKvp.Value is true)
+            if (Instance.Variables.TryGetValue("reload_addresses", out var reloadAddress) && reloadAddress is true)
             {
                 AddressString = _originalAddressString;
             }

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty.cs
@@ -138,7 +138,6 @@ namespace PokeAByte.Domain.PokeAByteProperties
                 return;
             }
 
-            byte[]? previousBytes = Bytes?.ToArray();
             byte[] bytes;
             object? value;
 
@@ -157,7 +156,7 @@ namespace PokeAByte.Domain.PokeAByteProperties
             
             Address = address;
             
-            if (previousBytes != null && bytes != null && previousBytes.SequenceEqual(bytes))
+            if (Bytes != null && Bytes.AsSpan().SequenceEqual(bytes))
             {
                 // Fast path - if the bytes match, then we can assume the property has not been
                 // updated since last poll.

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty_Malleable.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty_Malleable.cs
@@ -63,7 +63,7 @@ namespace PokeAByte.Domain.PokeAByteProperties
 
                 try
                 {
-                    IsMemoryAddressSolved = AddressMath.TrySolve(value, [], out var solvedAddress);
+                    IsMemoryAddressSolved = AddressMath.TrySolve(value, Instance.Variables, out var solvedAddress);
                     
                     if (IsMemoryAddressSolved == false)
                     {

--- a/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty_Malleable.cs
+++ b/src/PokeAByte.Domain/PokeAByteProperties/_PokeAByteProperty_Malleable.cs
@@ -1,4 +1,5 @@
-﻿using PokeAByte.Domain.Interfaces;
+﻿using NCalc;
+using PokeAByte.Domain.Interfaces;
 
 namespace PokeAByte.Domain.PokeAByteProperties
 {
@@ -60,10 +61,19 @@ namespace PokeAByte.Domain.PokeAByteProperties
                 if (value == _addressString) { return; }
 
                 _addressString = value;
-
+                _hasAddressParameter = false;
+                _addressExpression = !string.IsNullOrEmpty(value) 
+                    ? new Expression(value)
+                    : null;
                 try
                 {
-                    IsMemoryAddressSolved = AddressMath.TrySolve(value, Instance.Variables, out var solvedAddress);
+                    if (_addressExpression!=null) {
+                        _addressExpression.EvaluateParameter += OnParamEvaluation;
+                    }
+                    IsMemoryAddressSolved = AddressMath.TrySolve(_addressExpression, Instance.Variables, out var solvedAddress);
+                    if (_addressExpression!=null) {
+                        _addressExpression.EvaluateParameter -= OnParamEvaluation;
+                    }
                     
                     if (IsMemoryAddressSolved == false)
                     {
@@ -82,6 +92,11 @@ namespace PokeAByte.Domain.PokeAByteProperties
 
                 FieldsChanged.Add("address");
             }
+        }
+
+        private void OnParamEvaluation(string name, ParameterArgs args)
+        {
+            _hasAddressParameter = true;
         }
 
         public int? Length

--- a/src/PokeAByte.Domain/PropertyChangedEventArgs.cs
+++ b/src/PokeAByte.Domain/PropertyChangedEventArgs.cs
@@ -1,8 +1,8 @@
 ﻿using PokeAByte.Domain.Interfaces;
 
 namespace PokeAByte.Domain;
-public class PropertyChangedEventArgs(List<IPokeAByteProperty> changedProperties) : EventArgs
+public class PropertyChangedEventArgs(IList<IPokeAByteProperty> changedProperties) : EventArgs
 {
-    public List<IPokeAByteProperty> ChangedProperties { get; } = changedProperties;
+    public IList<IPokeAByteProperty> ChangedProperties { get; } = changedProperties;
 }
 public delegate void PropertyChangedEventHandler(object sender, PropertyChangedEventArgs e);

--- a/src/PokeAByte.Infrastructure/Drivers/Bizhawk/BizhawkMemoryMapDriver.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/Bizhawk/BizhawkMemoryMapDriver.cs
@@ -94,15 +94,15 @@ namespace PokeAByte.Infrastructure.Drivers.Bizhawk
             var platform = SharedPlatformConstants.Information.SingleOrDefault(x => x.BizhawkIdentifier == SystemName) ?? throw new Exception($"System {SystemName} is not yet supported.");
 
             var data = GetFromMemoryMappedFile("POKEABYTE_BIZHAWK_DATA.bin", DATA_Length);
-
-            return Task.FromResult(
-                platform.MemoryLayout.Select(
-                    x => new BlockData(
-                        x.PhysicalEndingAddress, 
-                        data[x.CustomPacketTransmitPosition..(x.CustomPacketTransmitPosition + x.Length)]
-                    )
-                ).ToArray()
-            );
+            var result = new BlockData[platform.MemoryLayout.Length];
+            for(int i = 0; i < result.Length; i++) {
+                var block = platform.MemoryLayout[i];
+                result[i] = new BlockData(
+                    block.PhysicalStartingAddress, 
+                    data[block.CustomPacketTransmitPosition..(block.CustomPacketTransmitPosition + block.Length)]
+                );
+            }
+            return  Task.FromResult(result);
         }
 
         public Task WriteBytes(uint startingMemoryAddress, byte[] values, string? path = null)

--- a/src/PokeAByte.Infrastructure/Drivers/Bizhawk/BizhawkMemoryMapDriver.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/Bizhawk/BizhawkMemoryMapDriver.cs
@@ -89,16 +89,20 @@ namespace PokeAByte.Infrastructure.Drivers.Bizhawk
             }
         }
 
-        public Task<Dictionary<uint, byte[]>> ReadBytes(IEnumerable<MemoryAddressBlock> blocks)
+        public Task<BlockData[]> ReadBytes(IList<MemoryAddressBlock> _)
         {
             var platform = SharedPlatformConstants.Information.SingleOrDefault(x => x.BizhawkIdentifier == SystemName) ?? throw new Exception($"System {SystemName} is not yet supported.");
 
             var data = GetFromMemoryMappedFile("POKEABYTE_BIZHAWK_DATA.bin", DATA_Length);
 
-            return Task.FromResult(platform.MemoryLayout.ToDictionary(
-                x => x.PhysicalStartingAddress,
-                x => data[x.CustomPacketTransmitPosition..(x.CustomPacketTransmitPosition + x.Length)]
-            ));
+            return Task.FromResult(
+                platform.MemoryLayout.Select(
+                    x => new BlockData(
+                        x.PhysicalEndingAddress, 
+                        data[x.CustomPacketTransmitPosition..(x.CustomPacketTransmitPosition + x.Length)]
+                    )
+                ).ToArray()
+            );
         }
 
         public Task WriteBytes(uint startingMemoryAddress, byte[] values, string? path = null)

--- a/src/PokeAByte.Infrastructure/Drivers/Bizhawk/BizhawkMemoryMapDriver.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/Bizhawk/BizhawkMemoryMapDriver.cs
@@ -72,6 +72,8 @@ namespace PokeAByte.Infrastructure.Drivers.Bizhawk
             return Task.CompletedTask;
         }
 
+        public Task Disconnect() => Task.CompletedTask;
+
         public Task<bool> TestConnection()
         {
             try

--- a/src/PokeAByte.Infrastructure/Drivers/StaticMemoryDriver.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/StaticMemoryDriver.cs
@@ -50,14 +50,14 @@ namespace PokeAByte.Infrastructure.Drivers
             MemoryFragmentLayout = JsonSerializer.Deserialize<Dictionary<uint, byte[]>>(contents) ?? throw new Exception("Cannot deserialize memory fragment layout.");
         }
 
-        public Task<Dictionary<uint, byte[]>> ReadBytes(IEnumerable<MemoryAddressBlock> blocks)
+        public Task<BlockData[]> ReadBytes(IList<MemoryAddressBlock> blocks)
         {
             if (BuildEnvironment.IsDebug == false)
             {
                 throw new Exception("Static Memory Driver operations are not allowed if not in DEBUG mode.");
             }
 
-            return Task.FromResult(MemoryFragmentLayout);
+            return Task.FromResult(MemoryFragmentLayout.Select(x => new BlockData(x.Key, x.Value)).ToArray());
         }
         public Task WriteBytes(uint startingMemoryAddress, byte[] values, string? path = null)
         {

--- a/src/PokeAByte.Infrastructure/Drivers/StaticMemoryDriver.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/StaticMemoryDriver.cs
@@ -29,6 +29,8 @@ namespace PokeAByte.Infrastructure.Drivers
             return Task.CompletedTask;
         }
 
+        public Task Disconnect() => Task.CompletedTask;
+
         public Task<bool> TestConnection()
         {
             return Task.FromResult(_isConnected);

--- a/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpClient.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpClient.cs
@@ -118,7 +118,7 @@ public class RetroArchUdpClient : IDisposable
         while (retries > 0 && response == null)
         {
             _ = await _client.SendAsync(Encoding.ASCII.GetBytes($"{command} {argument}"));
-            SpinWait.SpinUntil(() => _receivedData != null, TimeSpan.FromMilliseconds(_timeout / 4));
+            SpinWait.SpinUntil(() => _receivedData != null, TimeSpan.FromMilliseconds(_timeout));
             response = _receivedData?.Buffer;
             _receivedData = null;
             retries--;

--- a/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpClient.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpClient.cs
@@ -11,172 +11,189 @@ namespace PokeAByte.Infrastructure.Drivers.UdpPolling;
 /// </summary>
 public class RetroArchUdpClient : IDisposable
 {
-    private static byte[] _readResponseStart = Encoding.ASCII.GetBytes("READ_CORE_MEMORY");
-    private UdpClient? _client;
-    private bool _isDisposed = false;
-    private bool _isConnected = false;
-    private Dictionary<string, byte[]> _responses = [];
-    private readonly int _timeout;
-    private readonly IPAddress _ipAddress;
-    private readonly int _port;
+	private static byte[] _readResponseStart = Encoding.ASCII.GetBytes("READ_CORE_MEMORY");
+	private UdpClient? _client;
+	private bool _isDisposed = false;
+	private bool _isConnected = false;
+	private Dictionary<string, byte[]> _responses = [];
+	private readonly int _timeout;
+	private readonly IPAddress _ipAddress;
+	private readonly int _port;
 
-    [MemberNotNullWhen(true, nameof(_client))]
-    public bool IsClientConnected =>
-        _isDisposed is false &&
-        _isConnected &&
-        _client is not null &&
-        _client.Client.Connected;
+	[MemberNotNullWhen(true, nameof(_client))]
+	public bool IsClientConnected =>
+		_isDisposed is false &&
+		_isConnected &&
+		_client is not null &&
+		_client.Client.Connected;
 
-    public UdpReceiveResult? _receivedData { get; private set; }
+	public UdpReceiveResult? _receivedData { get; private set; }
 
-    public RetroArchUdpClient(string host, int port, int timeout)
-    {
-        _timeout = timeout;
-        _ipAddress = IPAddress.Parse(host);
-        _port = port;
-        CreateClient();
-    }
+	public RetroArchUdpClient(string host, int port, int timeout)
+	{
+		_timeout = timeout;
+		_ipAddress = IPAddress.Parse(host);
+		_port = port;
+		CreateClient();
+	}
 
-    private void CreateClient()
-    {
-        _client = new UdpClient();
-        _client.Client.SetSocketOption(SocketOptionLevel.Socket,
-            SocketOptionName.ReuseAddress,
-            true);
-        _isDisposed = false;
-    }
+	private void CreateClient()
+	{
+		_client = new UdpClient();
+		_client.Client.SetSocketOption(SocketOptionLevel.Socket,
+			SocketOptionName.ReuseAddress,
+			true);
+		_isDisposed = false;
+	}
 
-    [MemberNotNullWhen(true, nameof(_client))]
-    private bool IsClientAlive()
-    {
-        if (!IsClientConnected)
-        {
-            Connect();
-        }
-        if (!IsClientConnected)
-        {
-            Dispose();
-            return false;
-        }
-        return true;
-    }
+	[MemberNotNullWhen(true, nameof(_client))]
+	private bool IsClientAlive()
+	{
+		if (!IsClientConnected)
+		{
+			Connect();
+		}
+		if (!IsClientConnected)
+		{
+			Dispose();
+			return false;
+		}
+		return true;
+	}
 
-    public void Connect()
-    {
-        if (IsClientConnected)
-        {
-            return;
-        }
-        if (_isDisposed || _client is null)
-        {
-            _isConnected = false;
-            CreateClient();
-        }
+	public void Connect()
+	{
+		if (IsClientConnected)
+		{
+			return;
+		}
+		if (_isDisposed || _client is null)
+		{
+			_isConnected = false;
+			CreateClient();
+		}
 
-        if (_isDisposed || _client is null)
-        {
-            Dispose();
-            throw new Exception("UdpClient is still NULL when connecting.");
-        }
-        _client.Connect(_ipAddress, _port);
-        _isConnected = true;
-    }
+		if (_isDisposed || _client is null)
+		{
+			Dispose();
+			throw new Exception("UdpClient is still NULL when connecting.");
+		}
+		_client.Connect(_ipAddress, _port);
+		_isConnected = true;
+	}
 
-    private static byte[] ParseReadMemoryResponse(ReadOnlySpan<byte> input)
-    {
-        var byteCount = input.Count((byte)' ') + 1;
-        // Then we can skip over the remaining span 3 characters at a time, slicing out each character-pair for the
-        // byte.Parse().
-        int offset = 0;
-        byte[] value = new byte[byteCount];
-        for (int i = 0; i < value.Length - 1; i++)
-        {
-            // While we do technically get ASCII and byte.Parse(ROS<byte>) parses utf8, we can still use it because
-            // UTF8 is backwards compatible with ASCII:
-            value[i] = byte.Parse(input.Slice(offset, 2), NumberStyles.HexNumber);
-            offset += 3;
-        }
-        return value;
-    }
+	private static int GetDigitFromHex(byte input)
+	{
+		return input switch
+		{
+			>= (byte)'a' and <= (byte)'f' => (input - (byte)'a' + 10),
+			>= (byte)'A' and <= (byte)'F' => (input - (byte)'A' + 10),
+			_ => input - '0',
+		};
+	}
+
+	private static byte ParseHexByte(ReadOnlySpan<byte> bytes)
+	{
+		return (byte)((GetDigitFromHex(bytes[0]) << 4) | GetDigitFromHex(bytes[1]));
+	}
 
 
-    public async Task<bool> ReceiveAsync()
-    {
-        if (!IsClientAlive())
-        {
-            return false;
-        }
-        try
-        {
-            var response = await _client.ReceiveAsync();
-            Span<byte> bytes = response.Buffer;
-            if (bytes.StartsWith(_readResponseStart)) {
-                bytes = bytes.Slice(17);
-                int space = bytes.IndexOf((byte)' ');
-                string address = Encoding.ASCII.GetString(bytes[..space]);
-                var data = ParseReadMemoryResponse(bytes.Slice(space+1));
-                _responses[string.Concat(address, "-", data.Length.ToString())] = data;
-            }
-            return true;
-        }
-        catch
-        {
-            return false;
-        }
-    }
+	private static byte[] ParseReadMemoryResponse(ReadOnlySpan<byte> input)
+	{
+		var byteCount = input.Count((byte)' ') + 1;
+		// Then we can skip over the remaining span 3 characters at a time, slicing out each character-pair for the
+		// byte.Parse().
+		int offset = 0;
+		byte[] value = new byte[byteCount];
+		for (int i = 0; i < value.Length - 1; i++)
+		{
+			// While we do technically get ASCII and byte.Parse(ROS<byte>) parses utf8, we can still use it because
+			// UTF8 is backwards compatible with ASCII:
+			value[i] = ParseHexByte(input.Slice(offset, 2));
+			offset += 3;
+		}
+		return value;
+	}
 
-    /// <summary>
-    /// Send a command to the emulator without waiting for a response.
-    /// </summary>
-    /// <param name="command"> The emulator command. </param>
-    /// <param name="argument"> Emulator command arguments. </param>
-    /// <exception cref="Exception">
-    /// The UDP client is unitiliazed, disconnected, has been disposed, or is in an otherwise unusable state.
-    /// </exception>
-    public async Task SendAsync(string command, string argument)
-    {
-        if (!IsClientAlive())
-        {
-            throw new Exception($"Unable to create UdpClient to SendPacket({command} {argument})");
-        }
-        _ = await _client.SendAsync(Encoding.ASCII.GetBytes($"{command} {argument}"));
-    }
 
-    /// <summary>
-    /// Send a command to the emulator and return the response as a string.
-    /// </summary>
-    /// <param name="command"> The emulator command. </param>
-    /// <param name="argument"> Emulator command arguments. </param>
-    /// <returns> The response from the emulator, as an ASCII byte array. </returns>
-    /// <exception cref="Exception">
-    /// The UDP client is unitiliazed, disconnected, has been disposed, or is in an otherwise unusable state.
-    /// </exception>
-    public async Task<byte[]?> SendCommandAsync(string command, string argument1, string argument2)
-    {
-        if (!IsClientAlive())
-        {
-            throw new Exception($"Unable to create UdpClient to SendPacket({command} {argument1} {argument2})");
-        }
-        byte[]? response = null;
-        _ = await _client.SendAsync(Encoding.ASCII.GetBytes($"{command} {argument1} {argument2}"));
-        string key = string.Concat(argument1, "-", argument2);
-        SpinWait.SpinUntil(() =>
-            { 
-                return _responses.TryGetValue(key, out response);
-            }, 
-            TimeSpan.FromMilliseconds(_timeout)
-        );
-        return response;
-    }
+	public async Task<bool> ReceiveAsync()
+	{
+		if (!IsClientAlive())
+		{
+			return false;
+		}
+		try
+		{
+			var response = await _client.ReceiveAsync();
+			Span<byte> bytes = response.Buffer;
+			if (bytes.StartsWith(_readResponseStart))
+			{
+				bytes = bytes.Slice(17);
+				int space = bytes.IndexOf((byte)' ');
+				string address = Encoding.ASCII.GetString(bytes[..space]);
+				var data = ParseReadMemoryResponse(bytes.Slice(space + 1));
+				_responses[string.Concat(address, "-", data.Length.ToString())] = data;
+			}
+			return true;
+		}
+		catch
+		{
+			return false;
+		}
+	}
 
-    public void Dispose()
-    {
-        if (!_isDisposed)
-        {
-            _client?.Dispose();
-        }
-        _isConnected = false;
-        _isDisposed = true;
-        _client = null;
-    }
+	/// <summary>
+	/// Send a command to the emulator without waiting for a response.
+	/// </summary>
+	/// <param name="command"> The emulator command. </param>
+	/// <param name="argument"> Emulator command arguments. </param>
+	/// <exception cref="Exception">
+	/// The UDP client is unitiliazed, disconnected, has been disposed, or is in an otherwise unusable state.
+	/// </exception>
+	public async Task SendAsync(string command, string argument)
+	{
+		if (!IsClientAlive())
+		{
+			throw new Exception($"Unable to create UdpClient to SendPacket({command} {argument})");
+		}
+		_ = await _client.SendAsync(Encoding.ASCII.GetBytes($"{command} {argument}"));
+	}
+
+	/// <summary>
+	/// Send a command to the emulator and return the response as a string.
+	/// </summary>
+	/// <param name="command"> The emulator command. </param>
+	/// <param name="argument"> Emulator command arguments. </param>
+	/// <returns> The response from the emulator, as an ASCII byte array. </returns>
+	/// <exception cref="Exception">
+	/// The UDP client is unitiliazed, disconnected, has been disposed, or is in an otherwise unusable state.
+	/// </exception>
+	public async Task<byte[]?> SendCommandAsync(string command, string argument1, string argument2)
+	{
+		if (!IsClientAlive())
+		{
+			throw new Exception($"Unable to create UdpClient to SendPacket({command} {argument1} {argument2})");
+		}
+		byte[]? response = null;
+		_ = await _client.SendAsync(Encoding.ASCII.GetBytes($"{command} {argument1} {argument2}"));
+		string key = string.Concat(argument1, "-", argument2);
+		SpinWait.SpinUntil(() =>
+			{
+				return _responses.TryGetValue(key, out response);
+			},
+			TimeSpan.FromMilliseconds(_timeout)
+		);
+		return response;
+	}
+
+	public void Dispose()
+	{
+		if (!_isDisposed)
+		{
+			_client?.Dispose();
+		}
+		_isConnected = false;
+		_isDisposed = true;
+		_client = null;
+	}
 }

--- a/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpClient.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpClient.cs
@@ -116,7 +116,7 @@ public class RetroArchUdpClient : IDisposable
 	}
 
 
-	public async Task<bool> ReceiveAsync()
+	public async Task<bool> ReceiveAsync(CancellationToken cancellationToken)
 	{
 		if (!IsClientAlive())
 		{
@@ -124,7 +124,7 @@ public class RetroArchUdpClient : IDisposable
 		}
 		try
 		{
-			var response = await _client.ReceiveAsync();
+			var response = await _client.ReceiveAsync(cancellationToken);
 			Span<byte> bytes = response.Buffer;
 			if (bytes.StartsWith(_readResponseStart))
 			{

--- a/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpDriver.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpDriver.cs
@@ -8,45 +8,52 @@ namespace PokeAByte.Infrastructure.Drivers.UdpPolling;
 
 public class RetroArchUdpDriver : IPokeAByteDriver, IRetroArchUdpPollingDriver
 {
-    private CancellationTokenSource _connectionCts = new();
+    private CancellationTokenSource? _connectionCts;
     public string ProperName { get; } = "RetroArch";
     public int DelayMsBetweenReads { get; }
     private ILogger<RetroArchUdpDriver> Logger { get; }
     private readonly AppSettings _appSettings;
-    private RetroArchUdpClient _udpClientWrapper;
+    private RetroArchUdpClient? _udpClientWrapper;
 
     public RetroArchUdpDriver(ILogger<RetroArchUdpDriver> logger, AppSettings appSettings)
     {
         Logger = logger;
         DelayMsBetweenReads = appSettings.RETROARCH_DELAY_MS_BETWEEN_READS;
         _appSettings = appSettings;
+        
+    }
+
+    private static string ToRetroArchHexdecimalString(uint value) => value <= 9 ? $"{value}" : $"{value:X2}".ToLower();
+
+    private Task ConnectAsync(CancellationToken cancellationToken)
+    {
         _udpClientWrapper = new RetroArchUdpClient(
             _appSettings.RETROARCH_LISTEN_IP_ADDRESS,
             _appSettings.RETROARCH_LISTEN_PORT,
             _appSettings.RETROARCH_READ_PACKET_TIMEOUT_MS
         );
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
-            await ConnectAsync(_connectionCts.Token);
-        });
-    }
-
-    private static string ToRetroArchHexdecimalString(uint value) => value <= 9 ? $"{value}" : $"{value:X2}".ToLower();
-
-    private async Task ConnectAsync(CancellationToken cancellationToken)
-    {
-        _udpClientWrapper.Connect();
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            if (!await _udpClientWrapper.ReceiveAsync())
+            while (!cancellationToken.IsCancellationRequested)
             {
-                _udpClientWrapper.Dispose();
+                if (!await _udpClientWrapper.ReceiveAsync(cancellationToken))
+                {
+                    _udpClientWrapper.Dispose();
+                }
             }
-        }
+            _udpClientWrapper.Dispose();
+            _udpClientWrapper = null;
+        });
+        return Task.CompletedTask;
     }
 
     private async Task<byte[]> ReadMemoryAddress(uint memoryAddress, uint length)
     {
+        if (_udpClientWrapper == null) 
+        {
+            Logger.LogDebug("Can not read memory, UDP client is unitialized.");
+            throw new DriverTimeoutException(memoryAddress, ProperName, null);
+        }
         var command = $"READ_CORE_MEMORY";
         byte[]? response = await _udpClientWrapper.SendCommandAsync(
             command, 
@@ -56,7 +63,7 @@ public class RetroArchUdpDriver : IPokeAByteDriver, IRetroArchUdpPollingDriver
         if (response == null)
         {
             Logger.LogDebug($"A timeout occurred when waiting for ReadMemoryAddress reply from RetroArch. ({command})");
-            throw new DriverTimeoutException(memoryAddress, "RetroArch", null);
+            throw new DriverTimeoutException(memoryAddress, ProperName, null);
         }
         return response;
     }
@@ -66,6 +73,16 @@ public class RetroArchUdpDriver : IPokeAByteDriver, IRetroArchUdpPollingDriver
     /// </summary>
     /// <returns> A completed task. </returns>
     public Task EstablishConnection() => Task.CompletedTask;
+    
+
+    public async Task Disconnect() {
+        if (_connectionCts != null)
+        {
+            await _connectionCts.CancelAsync();
+            _connectionCts.Dispose();
+            _connectionCts = null;
+        }
+    }
 
     /// <summary>
     /// Tests the connect to retroarch by reading the very first byte of game memory.
@@ -75,6 +92,9 @@ public class RetroArchUdpDriver : IPokeAByteDriver, IRetroArchUdpPollingDriver
     /// </returns>
     public async Task<bool> TestConnection()
     {
+        _connectionCts = new CancellationTokenSource();
+        await ConnectAsync(_connectionCts.Token);
+        
         try
         {
             _ = await ReadMemoryAddress(0, 1);
@@ -95,6 +115,9 @@ public class RetroArchUdpDriver : IPokeAByteDriver, IRetroArchUdpPollingDriver
     /// <returns> An awaitable task. </returns>
     public async Task WriteBytes(uint memoryAddress, byte[] values, string? path = null)
     {
+        if (_udpClientWrapper == null) {
+            return;
+        }
         var bytes = string.Join(' ', values.Select(x => x.ToHexdecimalString()));
         await _udpClientWrapper.SendAsync(
             "WRITE_CORE_MEMORY",

--- a/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpDriver.cs
+++ b/src/PokeAByte.Infrastructure/Drivers/UdpPolling/RetroArchUdpDriver.cs
@@ -128,13 +128,14 @@ public class RetroArchUdpDriver : IPokeAByteDriver, IRetroArchUdpPollingDriver
     /// Key is the start of each address block. <br/>
     /// Value is the byte array contained in that block.
     /// </returns>
-    public async Task<Dictionary<uint, byte[]>> ReadBytes(IEnumerable<MemoryAddressBlock> blocks)
+    public async Task<BlockData[]> ReadBytes(IList<MemoryAddressBlock> blocks)
     {
-        var result = new Dictionary<uint, byte[]>();
-        foreach (var block in blocks)
+        var result = new BlockData[blocks.Count];
+        for (int i = 0; i < blocks.Count; i++)
         {
+            MemoryAddressBlock? block = blocks[i];
             var data = await ReadMemoryAddress(block.StartingAddress, block.EndingAddress - block.StartingAddress + 1);
-            result[block.StartingAddress] = data;
+            result[i] = new BlockData(block.StartingAddress, data);
         }
         return result;
     }

--- a/src/PokeAByte.Web/ClientNotifiers/WebSocketClientNotifier.cs
+++ b/src/PokeAByte.Web/ClientNotifiers/WebSocketClientNotifier.cs
@@ -39,10 +39,9 @@ namespace PokeAByte.Web.ClientNotifiers
             _hubContext.Clients.All.SendAsync("Error", problemDetails);
 
         public event PropertyChangedEventHandler? PropertyChangedEvent;
-        public async Task SendPropertiesChanged(IEnumerable<IPokeAByteProperty> properties)
+        public async Task SendPropertiesChanged(IList<IPokeAByteProperty> properties)
         {
-            var props = properties.ToList();
-            await _hubContext.Clients.All.SendAsync("PropertiesChanged", props.Select(x => new
+            await _hubContext.Clients.All.SendAsync("PropertiesChanged", properties.Select(x => new
             {
                 path = x.Path,
                 memoryContainer = x.MemoryContainer,
@@ -59,8 +58,8 @@ namespace PokeAByte.Web.ClientNotifiers
                 isReadOnly = x.IsReadOnly,
 
                 fieldsChanged = x.FieldsChanged
-            }).ToArray());
-            OnPropertyChangedEvent(new PropertyChangedEventArgs(props));
+            }));
+            OnPropertyChangedEvent(new PropertyChangedEventArgs(properties));
         }
 
         protected virtual void OnPropertyChangedEvent(PropertyChangedEventArgs args)

--- a/src/PokeAByte.Web/ClientNotifiers/WebSocketClientNotifier.cs
+++ b/src/PokeAByte.Web/ClientNotifiers/WebSocketClientNotifier.cs
@@ -53,7 +53,7 @@ namespace PokeAByte.Web.ClientNotifiers
                 bits = x.Bits,
                 description = x.Description,
                 value = x.Value,
-                bytes = x.Bytes?.Select(x => (int)x).ToArray(),
+                bytes = x.Bytes?.ToIntegerArray(),
 
                 isFrozen = x.IsFrozen,
                 isReadOnly = x.IsReadOnly,

--- a/src/PokeAByte.Web/Components/PropertyManager/PropertyTextViewer.razor
+++ b/src/PokeAByte.Web/Components/PropertyManager/PropertyTextViewer.razor
@@ -36,9 +36,14 @@
         if (Presenter.Parent?.Expanded is false) return false;
         return true;
     }
-    private void RefreshSelf()
+    private void RefreshSelf(string path)
     {
-        StateHasChanged();
+        var treeItemData = Presenter as TreeItemData<PropertyTreeItem>;
+        
+        if (treeItemData?.Value?.FullPath == path) 
+        {
+            StateHasChanged();
+        }
     }
     private string GetWidth(PropertyTreePresenter presenter, string additionalInfo)
     {

--- a/src/PokeAByte.Web/Components/PropertyManager/PropertyTreeView.razor
+++ b/src/PokeAByte.Web/Components/PropertyManager/PropertyTreeView.razor
@@ -124,20 +124,21 @@
         _shouldRender = true;
     }
 
-    public Action? Refresh;
+    public Action<string>? Refresh;
 
-    public void AttachRefreshEvent(Action? refreshEvent)
+    public void AttachRefreshEvent(Action<string>? refreshEvent)
     {
         Refresh += refreshEvent;
     }
-    public void DetachRefreshEvent(Action? refreshEvent)
+    public void DetachRefreshEvent(Action<string>? refreshEvent)
     {
         Refresh -= refreshEvent;
     }
-    public void RefreshChildren()
+
+    public void RefreshChildren(string path)
     {
         //StateHasChanged();
-        Refresh?.Invoke();
+        Refresh?.Invoke(path);
     }
 
     public void Dispose()

--- a/src/PokeAByte.Web/Components/PropertyManager/PropertyValueViewer.razor
+++ b/src/PokeAByte.Web/Components/PropertyManager/PropertyValueViewer.razor
@@ -115,7 +115,7 @@
     }
 
     private void RefreshSelf()
-    {        
+    {
         StateHasChanged();
     }
     public void Dispose()

--- a/src/PokeAByte.Web/Components/PropertyManager/PropertyValueViewer.razor
+++ b/src/PokeAByte.Web/Components/PropertyManager/PropertyValueViewer.razor
@@ -114,9 +114,11 @@
         return true;
     }
 
-    private void RefreshSelf()
-    {
-        StateHasChanged();
+    private void RefreshSelf(string path)
+    {        
+        if (Context.Value.PropertyModel.Path == path) {
+            StateHasChanged();
+        }
     }
     public void Dispose()
     {

--- a/src/PokeAByte.Web/Controllers/MapperController.cs
+++ b/src/PokeAByte.Web/Controllers/MapperController.cs
@@ -277,7 +277,7 @@ namespace PokeAByte.Web.Controllers
                 return ApiHelper.MapperNotLoaded();
 
             var path = model.Path.StripEndingRoute().FromRouteToPath();
-            var actualBytes = model.Bytes.Select(x => (byte)x).ToArray();
+            var actualBytes = Array.ConvertAll(model.Bytes, x => (byte)x);
 
             var prop = Instance.Mapper.Properties[path];
 

--- a/src/PokeAByte.Web/Models/EditPropertyModel.cs
+++ b/src/PokeAByte.Web/Models/EditPropertyModel.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using PokeAByte.Domain;
+﻿using PokeAByte.Domain;
 using PokeAByte.Domain.Models;
 using PokeAByte.Domain.Models.Properties;
 
@@ -10,8 +9,8 @@ public class EditPropertyModel : PropertyModel
     public bool IsEditing { get; set; } = false;
     public Dictionary<ulong, string>? GlossaryReference { get; set; }
     private string _valueString = "";
-    public string ValueString 
-    { 
+    public string ValueString
+    {
         get => _valueString;
         set
         {
@@ -46,7 +45,7 @@ public class EditPropertyModel : PropertyModel
                     _valueString = value; //ValueToString(value);
                 }
             }
-            else if(!string.IsNullOrWhiteSpace(Reference) && GlossaryReference is not null)
+            else if (!string.IsNullOrWhiteSpace(Reference) && GlossaryReference is not null)
             {
                 var foundReference = GlossaryReference.Where(g =>
                         g.Value.Contains(value, StringComparison.InvariantCultureIgnoreCase))
@@ -120,7 +119,7 @@ public class EditPropertyModel : PropertyModel
             }
             if (string.IsNullOrEmpty(value))
                 return false;
-             //Try to get bytes
+            //Try to get bytes
             var bytes = BaseProperty.BytesFromValue(value);
             //try to get calculated value
             var val = BaseProperty.CalculateObjectValue(bytes);
@@ -159,9 +158,9 @@ public class EditPropertyModel : PropertyModel
                 return;
             }
             var foundReference = GlossaryReference
-                .Where(x => 
+                .Where(x =>
                     !string.IsNullOrWhiteSpace(x.Value) &&
-                    value.key == x.Key && 
+                    value.key == x.Key &&
                     value.value == x.Value)
                 .Select(g => new IntegerValueReference(g.Key, g.Value))
                 .FirstOrDefault();
@@ -197,8 +196,8 @@ public class EditPropertyModel : PropertyModel
     public string AddressString =>
         Address?.ToString("X") ?? "";
     public static EditPropertyModel FromPropertyModel(PropertyModel model)
-    {            
-        
+    {
+
         return new EditPropertyModel
         {
             ValueString = model.ValueAsString(),
@@ -255,14 +254,10 @@ public class EditPropertyModel : PropertyModel
             if (Type is not "string" && !string.IsNullOrWhiteSpace(Reference) && GlossaryReference is not null)
             {
                 var key = BitConverter.ToUInt64(arr, 0);
-                var foundRef = GlossaryReference?
-                    .Where(x => x.Key == key)
-                    .Select(y => y.Value)
-                    .FirstOrDefault();
-                if (!string.IsNullOrWhiteSpace(foundRef))
+                if (GlossaryReference.TryGetValue(key, out var foundRef) && !string.IsNullOrWhiteSpace(foundRef))
                 {
                     ValueString = foundRef;
-                }                
+                }
                 return;
             }
             ValueString = BaseProperty.ObjectFromBytes(arr)?.ToString() ?? "";

--- a/src/PokeAByte.Web/Models/EditPropertyModel.cs
+++ b/src/PokeAByte.Web/Models/EditPropertyModel.cs
@@ -20,13 +20,31 @@ public class EditPropertyModel : PropertyModel
                 _valueString = Value?.ToString() ?? "";
                 return;
             }
+            
             if (_valueString == value)
                 return;
+            
             if (string.IsNullOrEmpty(_valueString))
                 _valueString = value;
+            
             if (ValidateValue(value))
             {
-                _valueString = value; //ValueToString(value);
+                if (Type == "string")
+                {
+                    if (value.Length > Length)
+                    {
+                        var len = Length ?? value.Length;
+                        _valueString = value[..len];
+                    }
+                    else
+                    {
+                        _valueString = value;
+                    }
+                }
+                else
+                {
+                    _valueString = value; //ValueToString(value);
+                }
             }
             else if(!string.IsNullOrWhiteSpace(Reference) && GlossaryReference is not null)
             {
@@ -123,7 +141,7 @@ public class EditPropertyModel : PropertyModel
         return Type switch
         {
             "bool" or "bit" => bool.TryParse(value, out _),
-            "string" => Length >= (string.IsNullOrEmpty(value) ? 0 : value.Length),
+            "string" => true/*Length >= (string.IsNullOrEmpty(value) ? 0 : value.Length)*/,
             "int" or "nibble" => CanParseInt(value),
             "uint" => CanParseUInt(value)/*uint.TryParse(value, out _)*/,
             _ => false

--- a/src/PokeAByte.Web/Models/EditPropertyModel.cs
+++ b/src/PokeAByte.Web/Models/EditPropertyModel.cs
@@ -222,29 +222,19 @@ public class EditPropertyModel : PropertyModel
     {
         ValueString = Value?.ToString() ?? "";
     }
+    
     public bool UpdateFromPropertyModel(PropertyModel? model)
     {
-        var valueString = model?.Value?.ToString() ?? "";
-        var value = model?.Value;
-        var bytes = model?.Bytes;
-        var isFrozen = model?.IsFrozen;
-        var isReadOnly = model?.IsReadOnly ?? false;
-        var byteArray = new ByteArrayProperty(model?.Bytes, Length);
-        var changed = ValueString != valueString
-            || Value != value
-            || Bytes != bytes
-            || IsFrozen != isFrozen
-            || IsReadOnly != isReadOnly
-            || ByteArray != byteArray;
-        if (changed)  {
-            ValueString = valueString;
-            Value = value;
-            Bytes = bytes;
-            IsFrozen = isFrozen;
-            IsReadOnly = isReadOnly;
-            ByteArray = byteArray;
+        if (model?.BaseProperty.FieldsChanged.Any() is true)  {
+            ValueString = model?.Value?.ToString() ?? "";
+            Value = model?.Value;
+            Bytes = model?.Bytes;
+            IsFrozen = model?.IsFrozen;
+            IsReadOnly = model?.IsReadOnly ?? false;
+            ByteArray = new ByteArrayProperty(model?.Bytes, Length);
+            return true;
         }
-        return changed;
+        return false;
     }
 
     public void UpdateByteArray()

--- a/src/PokeAByte.Web/Models/EditPropertyModel.cs
+++ b/src/PokeAByte.Web/Models/EditPropertyModel.cs
@@ -222,14 +222,29 @@ public class EditPropertyModel : PropertyModel
     {
         ValueString = Value?.ToString() ?? "";
     }
-    public void UpdateFromPropertyModel(PropertyModel? model)
+    public bool UpdateFromPropertyModel(PropertyModel? model)
     {
-        ValueString = model?.Value?.ToString() ?? "";
-        Value = model?.Value;
-        Bytes = model?.Bytes;
-        IsFrozen = model?.IsFrozen;
-        IsReadOnly = model?.IsReadOnly ?? false;
-        ByteArray = new ByteArrayProperty(model?.Bytes, Length);
+        var valueString = model?.Value?.ToString() ?? "";
+        var value = model?.Value;
+        var bytes = model?.Bytes;
+        var isFrozen = model?.IsFrozen;
+        var isReadOnly = model?.IsReadOnly ?? false;
+        var byteArray = new ByteArrayProperty(model?.Bytes, Length);
+        var changed = ValueString != valueString
+            || Value != value
+            || Bytes != bytes
+            || IsFrozen != isFrozen
+            || IsReadOnly != isReadOnly
+            || ByteArray != byteArray;
+        if (changed)  {
+            ValueString = valueString;
+            Value = value;
+            Bytes = bytes;
+            IsFrozen = isFrozen;
+            IsReadOnly = isReadOnly;
+            ByteArray = byteArray;
+        }
+        return changed;
     }
 
     public void UpdateByteArray()

--- a/src/PokeAByte.Web/Pages/MapperManager.razor
+++ b/src/PokeAByte.Web/Pages/MapperManager.razor
@@ -7,6 +7,7 @@
 
 @using PokeAByte.Web.Services.Mapper
 @using PokeAByte.Web.Services.Properties
+@implements IDisposable
 <PageTitle>@PageTitle - Mappers</PageTitle>
 <MudText Typo="Typo.h4" GutterBottom="true">Mapper Manager</MudText>
 <MudStack Row="true" Justify="Justify.FlexStart" Class="d-flex pb-2 align-center">
@@ -126,5 +127,10 @@
         {
             await Clear();
         });
+    }
+
+	public void Dispose()
+    {
+		MapperConnectionService!.DetachOnReadExceptionHandler(OnReadExceptionOccuredHandler);
     }
 }

--- a/src/PokeAByte.Web/Pages/Properties.razor
+++ b/src/PokeAByte.Web/Pages/Properties.razor
@@ -111,10 +111,9 @@ else
 
     private async void HandlePropertyUpdate(object? sender, PropertyUpdateEventArgs propertyUpdateEventArgs)
     {
-        PropertyService.UpdateProperty(propertyUpdateEventArgs.Path);
-        //await InvokeAsync(StateHasChanged);
-        if (_propertyTreeView is not null)
-            await InvokeAsync(_propertyTreeView.RefreshChildren);
+        bool refresh = PropertyService.UpdateProperty(propertyUpdateEventArgs.Path);
+        if (_propertyTreeView is not null && refresh)
+            await InvokeAsync(() => _propertyTreeView.RefreshChildren(propertyUpdateEventArgs.Path)); 
     }
     protected override void OnAfterRender(bool firstRender)
     {

--- a/src/PokeAByte.Web/Services/Mapper/MapperClientService.cs
+++ b/src/PokeAByte.Web/Services/Mapper/MapperClientService.cs
@@ -179,7 +179,7 @@ public class MapperClientService
             _pendingUpdates.Add(prop.Path);
         }
 
-        if (_lastUpdate <= DateTime.UtcNow - TimeSpan.FromMilliseconds(100)) {
+        if (_lastUpdate <= DateTime.UtcNow - TimeSpan.FromMilliseconds(15)) {
 
             foreach (var path in _pendingUpdates)
             {

--- a/src/PokeAByte.Web/Services/Notifiers/PropertyUpdateService.cs
+++ b/src/PokeAByte.Web/Services/Notifiers/PropertyUpdateService.cs
@@ -7,6 +7,7 @@ public class PropertyUpdateService(ILogger<PropertyUpdateService> logger)
     public void NotifyChanges(string path)
     {
         var gotValue = EventHandlers.TryGetValue(path, out var eventHandler);
+
         if (gotValue)
         {
             eventHandler?.Invoke(this, new PropertyUpdateEventArgs

--- a/src/PokeAByte.Web/Services/Properties/PropertyService.cs
+++ b/src/PokeAByte.Web/Services/Properties/PropertyService.cs
@@ -149,13 +149,13 @@ public class PropertyService(MapperClientService clientService,
         }
     }
 
-    public void UpdateProperty(string path)
+    public bool UpdateProperty(string path)
     {
         //Find path
         var property = _propertyTree.FindWithPath(path);
         var updatedModel = Client.GetPropertyByPath(path);
         if (updatedModel is null || property is null)
-            return;
-        property.PropertyModel?.UpdateFromPropertyModel(updatedModel);
+            return false;
+        return property.PropertyModel?.UpdateFromPropertyModel(updatedModel) ?? false;
     }
 }

--- a/src/PokeAByte.Web/Services/Properties/PropertyService.cs
+++ b/src/PokeAByte.Web/Services/Properties/PropertyService.cs
@@ -1,5 +1,4 @@
 ﻿using MudBlazor;
-using PokeAByte.Domain.Models.Properties;
 using PokeAByte.Web.Models;
 using PokeAByte.Web.Services.Mapper;
 using PokeAByte.Web.Services.Notifiers;
@@ -129,10 +128,7 @@ public class PropertyService(MapperClientService clientService,
             return;
         foreach (var property in clientProperties)
         {
-            var found = propertyUpdateService
-                .EventHandlers
-                .FirstOrDefault(x => x.Key == property.Path);
-            if (string.IsNullOrWhiteSpace(found.Key))
+            if (!propertyUpdateService.EventHandlers.ContainsKey(property.Path))
             {
                 propertyUpdateService.EventHandlers.TryAdd(property.Path, handlePropertyUpdate);
             }
@@ -146,11 +142,10 @@ public class PropertyService(MapperClientService clientService,
             return;
         foreach (var property in clientProperties)
         {
-            var found = propertyUpdateService
-                .EventHandlers
-                .FirstOrDefault(x => x.Key == property.Path);
-            if (!string.IsNullOrWhiteSpace(found.Key))
-                propertyUpdateService.EventHandlers.Remove(found.Key);
+            if (propertyUpdateService.EventHandlers.ContainsKey(property.Path)) 
+            {
+                propertyUpdateService.EventHandlers.Remove(property.Path);
+            }
         }
     }
 


### PR DESCRIPTION
RetroArch driver: 
- Back to response pooling, to avoid slowing down the polling by too much.
- Changed the semaphore back to a spin wait, since it's less CPU intensive.
- Further improved the response parsing speed.
- Changed all drivers `ReadBytes`  implementation to speed up response construction (Array instead of Dictionary)

PokeAByteProperty:
- Improved the "ToValue" performance of the `IPokeAByteProperty` implementations. With a focus on the IntegerProperty
- Improved the parsing speed of the `Bits` strings.
- Do not attempt to solve property address math without providing the instance variables. Avoids exception throw-catch with immediate retry.
- In the process loop, bail earlier when new and old data bytes are identical to avoid making byte array copies.

PokeAByteInstance:
- Evaluate the `reload_addresses` once right after the preprocessor ran.
- Track changed properties by utilizing a List and the for-loop that processes the individual properties.

IMemoryManager:
- Added a new API to get a `ReadOnlySpan<byte>` over a memory chunk. This can help avoid making very costly copies where they are not needed.
- Switched to a regular for loop instead of foreach, as the profiler was indicating quite a lot of additional memory allocation for Enumerator instances.
- Use `Span<byte>.CopyTo()` in the Fill method, since it's drastically faster.
- Reduced the number of calls to `get_bytes` in the various `get_uint*` methods.

Frontend:
- Added adjustable property update batching in the `MapperClientService`.
- Added some logic to the blazor UI code and `PropertyService` to avoid re-rendering property tree leaves that are not affected by property changes.

Misc.:
- Prefer `Dictionary<T,K>.TryGetValue()` over LINQ.
- Prefer `Array.ConvertAll()` over LINQ.
- Added a `copy_properties` API for javascript, because that happens to be a particularly expensive operation in Jint.
- Removed a superfluous `.ToArray()` and use `IList` for parameters in WebSocketClientNotifier

(The individual commits contain more details)

Replaces #15 #13 #14 